### PR TITLE
Make Line initializer publicly accessible

### DIFF
--- a/Sources/RoughSwift/Engine/Drawable.swift
+++ b/Sources/RoughSwift/Engine/Drawable.swift
@@ -23,6 +23,14 @@ public struct Line: Drawable {
 
     let from: Point
     let to: Point
+    
+    public init(
+        from: Point,
+        to: Point
+    ) {
+        self.from = from
+        self.to = to
+    }
 }
 
 public struct Rectangle: Drawable {


### PR DESCRIPTION
The initializer is not accessible so a Line cannot be created from the application side.